### PR TITLE
Fix bug with dimensionality edge case

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -78,6 +78,8 @@ def get_speech_ts(wav: torch.Tensor,
     if to_concat:
         chunks = torch.Tensor(torch.cat(to_concat, dim=0))
         out = run_function(model, chunks)
+        if len(out.shape) == 1: # model dropped first dimention 
+            out = out.unsqueeze(0) # add missing dimention
         outs.append(out)
 
     outs = torch.cat(outs, dim=0)


### PR DESCRIPTION
In "get_speech_ts" function, If "chunks" variable has shape of (1, X) then "run_function(model, chunks)" will return a tensor of shape (Y,), but two dimensional (1, Y) tensor is needed to complete next "torch.cat" operation