### PR TITLE
fix int16_t bytes normalized to float

### DIFF
--- a/examples/cpp/silero-vad-onnx.cpp
+++ b/examples/cpp/silero-vad-onnx.cpp
@@ -46,10 +46,10 @@ public:
     // Call it in predict func. if you prefer raw bytes input.
     void bytes_to_float_tensor(const char *pcm_bytes) 
     {
-        std::memcpy(input.data(), pcm_bytes, window_size_samples * sizeof(int16_t));
+        const int16_t * in_data = reinterpret_cast<const int16_t*>(pcm_bytes);
         for (int i = 0; i < window_size_samples; i++)
         {
-            input[i] = static_cast<float>(input[i]) / 32768; // int16_t normalized to float
+            input[i] = static_cast<float>(in_data[i]) / 32768; // int16_t normalized to float
         }
     }
 


### PR DESCRIPTION
In the function bytes_to_float_tensor, direct copying of pcm_bytes using int16_t to the float type input has resulted in a complete alteration of the numerical values. Consequently, it is no longer possible to retrieve the original int16_t data, leading to a conversion error.