### PR TITLE
Perform in-place resampling during read_audio.

### DIFF
--- a/utils_vad.py
+++ b/utils_vad.py
@@ -122,12 +122,24 @@ class Validator():
 def read_audio(path: str,
                sampling_rate: int = 16000):
 
-    effects = [
-        ['channels', '1'],
-        ['rate', str(sampling_rate)]
-    ]
+    if 'sox' in torchaudio.list_available_backends():
+        effects = [
+            ['channels', '1'],
+            ['rate', str(sampling_rate)]
+        ]
 
-    wav, sr = torchaudio.sox_effects.apply_effects_file(path, effects=effects)
+        wav, sr = torchaudio.sox_effects.apply_effects_file(path, effects=effects)
+    else:
+        wav, sr = torchaudio.load(path)
+
+        if wav.size(0) > 1:
+            wav = wav.mean(dim=0, keepdim=True)
+
+        if sr != sampling_rate:
+            transform = torchaudio.transforms.Resample(orig_freq=sr,
+                                                       new_freq=sampling_rate)
+            wav = transform(wav)
+            sr = sampling_rate
 
     assert sr == sampling_rate
     return wav.squeeze(0)

--- a/utils_vad.py
+++ b/utils_vad.py
@@ -122,16 +122,12 @@ class Validator():
 def read_audio(path: str,
                sampling_rate: int = 16000):
 
-    wav, sr = torchaudio.load(path)
+    effects = [
+        ['channels', '1'],
+        ['rate', str(sampling_rate)]
+    ]
 
-    if wav.size(0) > 1:
-        wav = wav.mean(dim=0, keepdim=True)
-
-    if sr != sampling_rate:
-        transform = torchaudio.transforms.Resample(orig_freq=sr,
-                                                   new_freq=sampling_rate)
-        wav = transform(wav)
-        sr = sampling_rate
+    wav, sr = torchaudio.sox_effects.apply_effects_file(path, effects=effects)
 
     assert sr == sampling_rate
     return wav.squeeze(0)


### PR DESCRIPTION
For long audio files (a single ~800MB mp3 in my case, 48kHz sampling rate), torchaudio.load is extremely expensive memory-wise.

This code performs channel reduction and resampling on-the-fly, reducing the peak memory usage significantly.