### PR TITLE
Support both sox and sox_io backends for in-place audio resampling.

### DIFF
--- a/utils_vad.py
+++ b/utils_vad.py
@@ -122,7 +122,10 @@ class Validator():
 def read_audio(path: str,
                sampling_rate: int = 16000):
 
-    if 'sox_io' in torchaudio.list_audio_backends():
+    sox_backends = set(['sox', 'sox_io'])
+    audio_backends = torchaudio.list_audio_backends()
+
+    if len(sox_backends.intersection(audio_backends)) > 0:
         effects = [
             ['channels', '1'],
             ['rate', str(sampling_rate)]


### PR DESCRIPTION
Depending on the exact system installed, some systems use the 'sox' backend while others have the 'sox_io' backend.

Documentation from latest torchaudio says this should be sox: https://pytorch.org/audio/stable/generated/torchaudio.list_audio_backends.html?highlight=backends#torchaudio.list_audio_backends

I have seen either sox and sox_io on different machines I use.