### PR TITLE
Surface drop_chunks in init

### DIFF
--- a/src/silero_vad/__init__.py
+++ b/src/silero_vad/__init__.py
@@ -9,4 +9,5 @@ from silero_vad.utils_vad import (get_speech_timestamps,
                                   save_audio,
                                   read_audio,
                                   VADIterator,
-                                  collect_chunks)
+                                  collect_chunks,
+                                  drop_chunks)


### PR DESCRIPTION
Adding drop_chunks to init.py so it is surfaced along with collect_chunks.

Current workaround is 
`from silero_vad.utils_vad import drop_chunks`

After the change we can import it the same way we import other top level functions:
```
from silero_vad import (
                          get_speech_timestamps,
                          collect_chunks,
                          drop_chunks)
```