### PR TITLE
Fixes and refines - use_max_poss_sil_at_max_speech arg

### DIFF
--- a/src/silero_vad/utils_vad.py
+++ b/src/silero_vad/utils_vad.py
@@ -379,7 +379,7 @@ def get_speech_timestamps(audio: torch.Tensor,
                 prev_end = next_start = temp_end = 0
                 possible_ends = []
             else:
-                # Standard cut at max_speech_duration_s: prefer last valid silence (prev_end) if available
+                # Legacy max-speech cut (use_max_poss_sil_at_max_speech=False): prefer last valid silence (prev_end) if available
                 if prev_end:
                     current_speech['end'] = prev_end
                     speeches.append(current_speech)


### PR DESCRIPTION
Removed redundant "if temp_end != 0:" check.
Multiple "window_size_samples * i" - assigned to a variable.
Restored the previous functionality (which was broken) when use_max_poss_sil_at_max_speech=False.

@shashank14k was your https://github.com/snakers4/silero-vad/pull/664 PR still WIP when it was merged?
Anyway, please test if use_max_poss_sil_at_max_speech=True behaviour is same, and "False" is same as before your PR.