### PR TITLE
Restrict torchaudio version to <2.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
   "packaging",
   "torch>=1.12.0",
-  "torchaudio>=0.12.0",
+  "torchaudio>=0.12.0,<2.9.0",
   "onnxruntime>=1.16.1",
 ]
 


### PR DESCRIPTION
The `read_audio()` function calls `torchaudio.list_audio_backends()` which was removed in torchaudio 2.9.
https://docs.pytorch.org/audio/2.8/generated/torchaudio.list_audio_backends.html