### PR TITLE
Add ExecuTorch reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ Please see our [wiki](https://github.com/snakers4/silero-models/wiki) for releva
 <h2 align="center">Examples and VAD-based Community Apps</h2>
 <br/>
 
-- Example of VAD ONNX Runtime model usage in [C++](https://github.com/snakers4/silero-vad/tree/master/examples/cpp) 
+- Example of VAD ONNX Runtime model usage in [C++](https://github.com/snakers4/silero-vad/tree/master/examples/cpp)
+
+- Example of VAD [ExecuTorch](https://github.com/pytorch/executorch) model usage in [C++](https://github.com/pytorch/executorch/tree/main/examples/models/silero_vad)
 
 - Voice activity detection for the [browser](https://github.com/ricky0123/vad) using ONNX Runtime Web
 


### PR DESCRIPTION
It was enabled recently in: https://github.com/pytorch/executorch/tree/main/examples/models/silero_vad