### PR TITLE
Add OpenVINO conversion example (fixes If subgraph load failure)

### DIFF
--- a/examples/openvino/README.md
+++ b/examples/openvino/README.md
@@ -1,0 +1,66 @@
+# Silero VAD in OpenVINO
+
+The stock `silero_vad.onnx` does not load in OpenVINO. `read_model` fails with:
+
+```
+OpConversionFailure: Model wasn't fully converted.
+-- Conv-16: While validating ONNX node
+   '<Node(Conv): If_0_then_branch__Inline_0__/decoder/decoder/2/Conv_output_0>':
+   Check 'data.get_partial_shape().rank().is_static()' failed
+   The input data tensor's rank has to be known (static)
+```
+
+The ONNX frontend cannot infer static ranks for the Conv ops (the STFT) inside the If subgraphs. There is one top level If that switches between the 8 kHz and 16 kHz paths, plus 7 nested If nodes per branch left behind by TorchScript tracing, so folding the sample rate constant alone is not enough.
+
+None of those conditions depend on the audio itself, only on the sample rate and tensor shapes, so for a fixed configuration they can all be resolved offline. `convert.py` inlines every If by evaluating its condition empirically with onnxruntime, removes the dead branch including its weights (the file drops from 2.27 MB to 1.23 MB), folds Identity nodes (recent OpenVINO serializes them as opset16::Identity, which older CPU plugins cannot execute) and fixes static shapes. The result loads and compiles in OpenVINO directly, as ONNX or as exported IR.
+
+## Usage
+
+```
+pip install numpy onnx onnxruntime openvino
+
+python convert.py                  # writes silero_vad_16k.onnx
+python convert.py --sr 8000        # writes silero_vad_8k.onnx
+python convert.py --save-ir        # also exports OpenVINO IR
+
+python verify.py silero_vad_16k.onnx ../../tests/data/test.wav "../c++/aepyx.wav"
+python verify.py silero_vad_8k.onnx --sr 8000 "../c++/aepyx_8k.wav"
+```
+
+`convert.py` defaults to the model shipped in this repo. `verify.py` compares the converted model against the stock one with chained state, on synthetic audio and on any 16 bit mono wav files you pass, and checks that the resulting speech segmentation is identical. It exits nonzero if anything is off.
+
+## Set inference precision to f32
+
+On CPUs with bf16 support (AMX or AVX512 BF16) the OpenVINO CPU plugin defaults to bf16 inference. For this model that is not a harmless accuracy tradeoff: the per chunk error compounds through the recurrent state until the speech segmentation actually changes. On real audio the default gave max abs diffs up to 3e-1 against the stock model, while f32 gives 2e-6. Always compile with:
+
+```python
+compiled = core.compile_model(model, "CPU", {"INFERENCE_PRECISION_HINT": "f32"})
+```
+
+or `ov::hint::inference_precision(ov::element::f32)` in C++. The model is tiny, f32 costs nothing.
+
+## Inference
+
+I/O contract of the converted model: `input` f32 [1, 576] at 16 kHz (64 context samples followed by 512 new ones; [1, 288] as 32 plus 256 at 8 kHz), `state` f32 [2, 1, 128], outputs `output` f32 [1, 1] and `stateN` f32 [2, 1, 128]. Chain `stateN` back into `state`, keep the last 64 (or 32) input samples as the next context, and reset both to zeros when a new stream starts. Same protocol as the OnnxWrapper in this repo.
+
+```python
+import numpy as np
+import openvino as ov
+
+req = ov.Core().compile_model("silero_vad_16k.onnx", "CPU",
+    {"INFERENCE_PRECISION_HINT": "f32"}).create_infer_request()
+state = np.zeros((2, 1, 128), np.float32)
+ctx = np.zeros((1, 64), np.float32)
+for chunk in stream_of_512_sample_chunks:
+    x = np.concatenate([ctx, chunk[None]], axis=1)
+    res = req.infer({"input": x, "state": state})
+    prob, state, ctx = res["output"][0, 0], res["stateN"], x[:, -64:]
+```
+
+## Validation
+
+Converted vs stock, chained state throughout. In onnxruntime the converted model is bit exact (max abs diff 0.0) for both sample rates, so the transformation is the mathematical identity for the chosen rate. In OpenVINO with f32: at 16 kHz, max abs diff 2.3e-06 over `tests/data/test.wav` plus `examples/c++/aepyx.wav` (229 s, 7161 chunks) with identical segmentation (29 of 29 and 65 of 65 segments). At 8 kHz, max abs diff 4.5e-06 over `examples/c++/aepyx_8k.wav` with identical segmentation (79 of 79). Reproduced on Linux and Windows across two OpenVINO versions. Source model sha256 `1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3`.
+
+## Caveats
+
+Each converted model is single sample rate (the `sr` input is removed) with batch fixed to 1. Some of the inlined guards may be batch dependent, so batch 1 is validated exhaustively and larger batches are not. IR files are version sensitive: regenerate the IR with your target OpenVINO version, or load the cleaned ONNX directly with `read_model`.

--- a/examples/openvino/convert.py
+++ b/examples/openvino/convert.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Convert the Silero VAD ONNX model into an OpenVINO compatible one.
+
+The stock silero_vad.onnx does not load in OpenVINO: the ONNX frontend
+cannot infer static ranks for the Conv ops (the STFT) inside the If
+subgraphs. The graph contains one top level If that switches between the
+8 kHz and 16 kHz paths, plus 7 nested If nodes per branch left behind by
+TorchScript tracing. None of their conditions depend on the audio itself,
+only on the sample rate and tensor shapes, so for a fixed configuration
+they can all be resolved offline.
+
+This script inlines every If by evaluating its condition empirically with
+onnxruntime, removes dead code (including the weights of the unused sample
+rate branch), folds Identity nodes (recent OpenVINO serializes them as
+opset16::Identity, which older CPU plugins cannot execute) and fixes
+static shapes. The result loads with core.read_model() and compiles on
+CPU directly, both as ONNX and as exported IR.
+
+Usage:
+    python convert.py [--sr 16000] [--save-ir] [input.onnx] [output.onnx]
+
+Defaults: input is the model shipped in this repo, output is
+silero_vad_16k.onnx or silero_vad_8k.onnx depending on --sr.
+
+Requires: numpy, onnx, onnxruntime. OpenVINO only if --save-ir is used.
+"""
+import argparse
+import copy
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+from onnx import TensorProto, helper, shape_inference
+
+REPO_MODEL = Path(__file__).resolve().parents[2] / \
+    'src' / 'silero_vad' / 'data' / 'silero_vad.onnx'
+
+
+def defined_names(graph):
+    """Names defined inside a graph (ONNX scoping rules)."""
+    s = set(i.name for i in graph.initializer)
+    s |= set(i.name for i in graph.input)
+    for n in graph.node:
+        s |= set(o for o in n.output if o)
+    return s
+
+
+def deep_rename(node, rename):
+    """Rename references in a node, recursing into subgraphs with shadowing."""
+    for i, name in enumerate(node.input):
+        if name in rename:
+            node.input[i] = rename[name]
+    for i, name in enumerate(node.output):
+        if name in rename:
+            node.output[i] = rename[name]
+    for attr in node.attribute:
+        subgraphs = []
+        if attr.type == onnx.AttributeProto.GRAPH:
+            subgraphs = [attr.g]
+        elif attr.type == onnx.AttributeProto.GRAPHS:
+            subgraphs = list(attr.graphs)
+        for sg in subgraphs:
+            shadowed = defined_names(sg)
+            inner = {k: v for k, v in rename.items() if k not in shadowed}
+            if inner:
+                for sn in sg.node:
+                    deep_rename(sn, inner)
+                for o in sg.output:
+                    if o.name in inner:
+                        o.name = inner[o.name]
+
+
+def eval_cond(model, cond_name, feeds):
+    """Evaluate an If condition tensor by running the current model."""
+    probe = copy.deepcopy(model)
+    vi = helper.make_tensor_value_info(cond_name, TensorProto.BOOL, None)
+    probe.graph.output.append(vi)
+    so = ort.SessionOptions()
+    so.log_severity_level = 3
+    sess = ort.InferenceSession(probe.SerializeToString(), so,
+                                providers=['CPUExecutionProvider'])
+    out_names = [o.name for o in sess.get_outputs()]
+    needed = {i.name: feeds[i.name] for i in sess.get_inputs()}
+    res = sess.run(out_names, needed)
+    val = np.asarray(res[out_names.index(cond_name)]).reshape(-1)
+    assert val.size == 1, f"condition {cond_name} is not a scalar"
+    return bool(val[0])
+
+
+def inline_if(graph, if_idx, branch, prefix):
+    """Replace graph.node[if_idx] (an If) with the nodes of `branch`."""
+    if_node = graph.node[if_idx]
+    internal = set(i.name for i in branch.initializer)
+    for n in branch.node:
+        internal |= set(o for o in n.output if o)
+
+    rename = {name: f"{prefix}::{name}" for name in internal}
+
+    extra_identity = []
+    for b_out, if_out in zip(branch.output, if_node.output):
+        if b_out.name in internal:
+            rename[b_out.name] = if_out
+        else:
+            # branch output is a tensor captured from the outer scope
+            extra_identity.append(helper.make_node(
+                'Identity', [b_out.name], [if_out],
+                name=f"{prefix}::identity_{if_out}"))
+
+    new_nodes = []
+    for n in branch.node:
+        n2 = copy.deepcopy(n)
+        n2.name = f"{prefix}::{n2.name}" if n2.name else f"{prefix}::anon"
+        deep_rename(n2, rename)
+        new_nodes.append(n2)
+    new_nodes.extend(extra_identity)
+
+    for init in branch.initializer:
+        init2 = copy.deepcopy(init)
+        init2.name = rename.get(init.name, init.name)
+        graph.initializer.append(init2)
+
+    nodes = list(graph.node)
+    nodes[if_idx:if_idx + 1] = new_nodes
+    del graph.node[:]
+    graph.node.extend(nodes)
+
+
+def eliminate_identity(graph):
+    """Fold Identity nodes. They are pure metadata, but older OpenVINO CPU
+    plugins cannot execute opset16::Identity in serialized IR files."""
+    changed = True
+    while changed:
+        changed = False
+        out_names = set(o.name for o in graph.output)
+        for idx, n in enumerate(graph.node):
+            if n.op_type != 'Identity':
+                continue
+            src, dst = n.input[0], n.output[0]
+            if dst in out_names:
+                if src in out_names:
+                    continue  # output to output aliasing, keep it
+                producer = next((p for p in graph.node if src in p.output), None)
+                if producer is None:
+                    continue  # src is a graph input or initializer, keep it
+                for i, o in enumerate(producer.output):
+                    if o == src:
+                        producer.output[i] = dst
+                for p in graph.node:
+                    if p is not n:
+                        for i, inp in enumerate(p.input):
+                            if inp == src:
+                                p.input[i] = dst
+            else:
+                for p in graph.node:
+                    for i, inp in enumerate(p.input):
+                        if inp == dst:
+                            p.input[i] = src
+            del graph.node[idx]
+            changed = True
+            break
+
+
+def dce(graph):
+    """Drop nodes, initializers and inputs not reachable from the outputs."""
+    needed = set(o.name for o in graph.output)
+    kept = []
+    for n in reversed(list(graph.node)):
+        if any(o in needed for o in n.output):
+            kept.append(n)
+            needed |= set(i for i in n.input if i)
+            for attr in n.attribute:
+                sgs = [attr.g] if attr.type == onnx.AttributeProto.GRAPH \
+                    else list(attr.graphs) if attr.type == onnx.AttributeProto.GRAPHS else []
+                for sg in sgs:
+                    local = defined_names(sg)
+                    for sn in sg.node:
+                        needed |= set(i for i in sn.input if i and i not in local)
+    kept.reverse()
+    del graph.node[:]
+    graph.node.extend(kept)
+
+    keep_init = [i for i in graph.initializer if i.name in needed]
+    del graph.initializer[:]
+    graph.initializer.extend(keep_init)
+    keep_in = [i for i in graph.input if i.name in needed]
+    del graph.input[:]
+    graph.input.extend(keep_in)
+
+
+def convert(src, dst, sr, save_ir=False):
+    samples = 576 if sr == 16000 else 288  # new samples plus context
+    model = onnx.load(str(src))
+    feeds = {
+        'input': np.zeros((1, samples), dtype=np.float32),
+        'state': np.zeros((2, 1, 128), dtype=np.float32),
+        'sr':    np.array(sr, dtype=np.int64),
+    }
+
+    step = 0
+    while True:
+        ifs = [(i, n) for i, n in enumerate(model.graph.node) if n.op_type == 'If']
+        if not ifs:
+            break
+        idx, node = ifs[0]
+        cond = eval_cond(model, node.input[0], feeds)
+        branch_name = 'then_branch' if cond else 'else_branch'
+        branch = next(a.g for a in node.attribute if a.name == branch_name)
+        print(f"[{step}] inline If '{node.name}': cond={cond} -> {branch_name} "
+              f"({len(branch.node)} nodes)")
+        inline_if(model.graph, idx, branch, f"F{step}")
+        step += 1
+
+    assert not any(n.op_type in ('If', 'Loop', 'Scan') for n in model.graph.node)
+
+    dce(model.graph)
+    eliminate_identity(model.graph)
+
+    for i in model.graph.input:
+        dims = {'input': [1, samples], 'state': [2, 1, 128]}[i.name]
+        for d, v in zip(i.type.tensor_type.shape.dim, dims):
+            d.ClearField('dim_param')
+            d.dim_value = v
+    for o in model.graph.output:
+        dims = {'output': [1, 1], 'stateN': [2, 1, 128]}[o.name]
+        for d, v in zip(o.type.tensor_type.shape.dim, dims):
+            d.ClearField('dim_param')
+            d.dim_value = v
+    del model.graph.value_info[:]
+
+    model = shape_inference.infer_shapes(model)
+    onnx.checker.check_model(model)
+    onnx.save(model, str(dst))
+
+    n_if = sum(1 for n in model.graph.node if n.op_type == 'If')
+    n_id = sum(1 for n in model.graph.node if n.op_type == 'Identity')
+    print(f"\nwrote {dst}")
+    print(f"  nodes: {len(model.graph.node)}, If left: {n_if}, "
+          f"Identity left: {n_id}, inputs: {[i.name for i in model.graph.input]}")
+
+    if save_ir:
+        import openvino as ov
+        ir_path = Path(dst).with_suffix('.xml')
+        ov.save_model(ov.Core().read_model(str(dst)), str(ir_path),
+                      compress_to_fp16=False)
+        print(f"  IR written to {ir_path} (regenerate with your target "
+              f"OpenVINO version when deploying)")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument('input', nargs='?', default=str(REPO_MODEL),
+                   help='path to the stock silero_vad.onnx')
+    p.add_argument('output', nargs='?', default=None,
+                   help='output path (default: silero_vad_16k.onnx or _8k)')
+    p.add_argument('--sr', type=int, choices=[8000, 16000], default=16000,
+                   help='sample rate branch to keep (default 16000)')
+    p.add_argument('--save-ir', action='store_true',
+                   help='also export OpenVINO IR next to the output')
+    a = p.parse_args()
+    out = a.output or f"silero_vad_{a.sr // 1000}k.onnx"
+    convert(a.input, out, a.sr, a.save_ir)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/openvino/verify.py
+++ b/examples/openvino/verify.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Verify the converted model against the stock silero_vad.onnx.
+
+Runs a chained state comparison on synthetic audio in both onnxruntime
+and OpenVINO, and optionally on real wav files (16 bit mono PCM at the
+matching sample rate). The converted model should be bit exact against
+the stock one in onnxruntime, and within float rounding noise in
+OpenVINO, with identical speech segmentation.
+
+Usage:
+    python verify.py converted.onnx [--sr 16000] [--stock path] [wav ...]
+
+Exit code is nonzero if the onnxruntime comparison is not bit exact, if
+the OpenVINO max abs diff exceeds 1e-4, or if segmentation differs.
+
+Requires: numpy, onnx, onnxruntime, openvino.
+"""
+import argparse
+import sys
+import wave
+from pathlib import Path
+
+import numpy as np
+import onnxruntime as ort
+import openvino as ov
+
+REPO_MODEL = Path(__file__).resolve().parents[2] / \
+    'src' / 'silero_vad' / 'data' / 'silero_vad.onnx'
+
+
+def synthetic_audio(sr, rng):
+    """A varied stretch of synthetic audio. The comparison is numeric,
+    it does not need to be realistic speech."""
+    t = lambda sec: np.arange(int(sec * sr)) / sr
+    parts = [np.zeros(int(3 * sr), dtype=np.float32)]
+    tt = t(4)  # mains hum with harmonics
+    parts.append((0.02 * np.sin(2 * np.pi * 60 * tt)
+                  + 0.01 * np.sin(2 * np.pi * 120 * tt)
+                  + 0.005 * np.sin(2 * np.pi * 180 * tt)).astype(np.float32))
+    parts.append((0.05 * rng.standard_normal(int(3 * sr))).astype(np.float32))
+    tt = t(4)  # amplitude modulated noise with formant like tones
+    env = 0.5 * (1 + np.sign(np.sin(2 * np.pi * 4 * tt)))
+    carrier = np.sin(2 * np.pi * 220 * tt) + 0.6 * np.sin(2 * np.pi * 710 * tt) \
+        + 0.3 * np.sin(2 * np.pi * 2400 * tt)
+    parts.append((0.15 * env * carrier
+                  + 0.02 * rng.standard_normal(len(tt))).astype(np.float32))
+    tt = t(3)
+    parts.append((0.1 * np.sin(2 * np.pi * (100 + 900 * tt) * tt)).astype(np.float32))
+    parts.append((0.3 * rng.standard_normal(int(3 * sr))).astype(np.float32))
+    parts.append(np.zeros(int(2 * sr), dtype=np.float32))
+    return np.concatenate(parts)
+
+
+def load_wav(path, sr):
+    w = wave.open(str(path))
+    assert w.getframerate() == sr and w.getnchannels() == 1 \
+        and w.getsampwidth() == 2, f"{path}: expected {sr} Hz mono PCM16"
+    pcm = np.frombuffer(w.readframes(w.getnframes()), dtype=np.int16)
+    return pcm.astype(np.float32) / 32768.0
+
+
+class OrtStock:
+    def __init__(self, path, sr):
+        so = ort.SessionOptions()
+        so.log_severity_level = 3
+        self.s = ort.InferenceSession(str(path), so,
+                                      providers=['CPUExecutionProvider'])
+        self.sr = np.array(sr, dtype=np.int64)
+        self.ctx_size = 64 if sr == 16000 else 32
+
+    def reset(self):
+        self.state = np.zeros((2, 1, 128), np.float32)
+        self.ctx = np.zeros((1, self.ctx_size), np.float32)
+
+    def __call__(self, chunk):
+        x = np.concatenate([self.ctx, chunk[None]], axis=1)
+        p, self.state = self.s.run(
+            ['output', 'stateN'],
+            {'input': x, 'state': self.state, 'sr': self.sr})
+        self.ctx = x[:, -self.ctx_size:]
+        return float(p[0, 0])
+
+
+class OrtConverted(OrtStock):
+    def __call__(self, chunk):
+        x = np.concatenate([self.ctx, chunk[None]], axis=1)
+        p, self.state = self.s.run(['output', 'stateN'],
+                                   {'input': x, 'state': self.state})
+        self.ctx = x[:, -self.ctx_size:]
+        return float(p[0, 0])
+
+
+class OvConverted:
+    def __init__(self, path, sr):
+        core = ov.Core()
+        # Force f32 inference. On bf16 capable CPUs the OpenVINO CPU plugin
+        # defaults to bf16, and the per step error compounds through the
+        # recurrent state until the speech segmentation changes.
+        compiled = core.compile_model(str(path), 'CPU',
+                                      {'INFERENCE_PRECISION_HINT': 'f32'})
+        self.r = compiled.create_infer_request()
+        self.ctx_size = 64 if sr == 16000 else 32
+
+    def reset(self):
+        self.state = np.zeros((2, 1, 128), np.float32)
+        self.ctx = np.zeros((1, self.ctx_size), np.float32)
+
+    def __call__(self, chunk):
+        x = np.concatenate([self.ctx, chunk[None]], axis=1)
+        res = self.r.infer({'input': x, 'state': self.state})
+        self.state = res['stateN']
+        self.ctx = x[:, -self.ctx_size:]
+        return float(res['output'][0, 0])
+
+
+def segments(probs, thr=0.5, min_chunks=8):
+    segs, start = [], None
+    for i, p in enumerate(probs):
+        if p >= thr and start is None:
+            start = i
+        elif p < thr and start is not None:
+            if i - start >= min_chunks:
+                segs.append((start, i))
+            start = None
+    if start is not None and len(probs) - start >= min_chunks:
+        segs.append((start, len(probs)))
+    return segs
+
+
+def run(audio, chunk, engines):
+    for e in engines:
+        e.reset()
+    n = len(audio) // chunk
+    out = [[] for _ in engines]
+    for i in range(n):
+        c = audio[i * chunk:(i + 1) * chunk]
+        for j, e in enumerate(engines):
+            out[j].append(e(c))
+    return [np.array(o) for o in out]
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument('converted', help='path to the converted onnx')
+    p.add_argument('wavs', nargs='*', help='optional real wav files')
+    p.add_argument('--sr', type=int, choices=[8000, 16000], default=16000)
+    p.add_argument('--stock', default=str(REPO_MODEL),
+                   help='path to the stock silero_vad.onnx')
+    a = p.parse_intermixed_args()
+
+    chunk = 512 if a.sr == 16000 else 256
+    stock = OrtStock(a.stock, a.sr)
+    conv_ort = OrtConverted(a.converted, a.sr)
+    conv_ov = OvConverted(a.converted, a.sr)
+    print(f"sr={a.sr}, chunk={chunk}, OpenVINO {ov.__version__}, inference precision forced to f32")
+
+    ok = True
+    rng = np.random.default_rng(42)
+    audio = synthetic_audio(a.sr, rng)
+    ps, po, pv = run(audio, chunk, [stock, conv_ort, conv_ov])
+    d_ort = np.abs(po - ps).max()
+    d_ov = np.abs(pv - ps).max()
+    print(f"\nsynthetic ({len(audio)//chunk} chunks, chained state)")
+    print(f"  onnxruntime converted vs stock: max abs diff = {d_ort:.3e}"
+          f"  {'(bit exact)' if d_ort == 0 else 'EXPECTED 0.0'}")
+    print(f"  OpenVINO converted vs stock:    max abs diff = {d_ov:.3e}")
+    ok &= (d_ort == 0.0) and (d_ov < 1e-4)
+
+    for wav in a.wavs:
+        audio = load_wav(wav, a.sr)
+        ps, pv = run(audio, chunk, [stock, conv_ov])
+        d = np.abs(pv - ps).max()
+        s_ref, s_ov = segments(ps), segments(pv)
+        same = s_ref == s_ov
+        print(f"\n{wav} ({len(audio)/a.sr:.0f} s, {len(ps)} chunks)")
+        print(f"  OpenVINO vs stock: max abs diff = {d:.3e}")
+        print(f"  speech segments: stock={len(s_ref)} OpenVINO={len(s_ov)}"
+              f"  identical={same}")
+        ok &= same and (d < 1e-4)
+
+    print(f"\n{'PASS' if ok else 'FAIL'}")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The stock silero_vad.onnx cannot be loaded by OpenVINO. read_model fails with "The input data tensor's rank has to be known (static)" on the Conv ops inside the If subgraphs, as reported in #705. The graph has one top level If for the sample rate plus 7 nested If nodes per branch left behind by TorchScript tracing, so folding the sample rate constant alone is not enough.

This PR adds examples/openvino with a conversion script, a verification script and a README. convert.py inlines every If by evaluating its condition empirically with onnxruntime, removes the dead branch including its weights (2.27 MB to 1.23 MB), folds Identity nodes (recent OpenVINO serializes them as opset16::Identity, which older CPU plugins cannot execute) and fixes static shapes. It supports both sample rates through a --sr flag. The result loads and compiles in OpenVINO directly, as ONNX or exported IR.

One finding worth flagging on its own: on bf16 capable CPUs the OpenVINO CPU plugin defaults to bf16 inference, and for this model the per chunk error compounds through the recurrent state until the speech segmentation actually changes (measured up to 3e-1 max abs diff on real audio, against 2e-6 with f32). The README documents setting INFERENCE_PRECISION_HINT to f32, which costs nothing for a model this size.

Validation, with chained state throughout, against the stock model at commit dbacf53 (sha256 1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3). In onnxruntime the converted model is bit exact for both sample rates, so the transformation is the mathematical identity for the chosen rate. In OpenVINO with f32: max abs diff 2.3e-06 at 16 kHz on tests/data/test.wav plus examples/c++/aepyx.wav (229 seconds, 7161 chunks) and 4.5e-06 at 8 kHz on examples/c++/aepyx_8k.wav, with identical speech segmentation in all cases (29/29, 65/65 and 79/79 segments). Reproduced on Linux and Windows across two OpenVINO versions.

How to test:

```
cd examples/openvino
pip install numpy onnx onnxruntime openvino
python convert.py
python convert.py --sr 8000
python verify.py silero_vad_16k.onnx ../../tests/data/test.wav "../c++/aepyx.wav"
python verify.py silero_vad_8k.onnx --sr 8000 "../c++/aepyx_8k.wav"
```

verify.py exits nonzero unless the onnxruntime comparison is bit exact and the OpenVINO segmentation matches the stock model.

Caveats: each converted model is single sample rate with batch fixed to 1 (batch 1 is validated exhaustively, larger batches are not), and IR files should be regenerated with the target OpenVINO version, or the cleaned ONNX loaded directly with read_model.

Closes #705. Also relevant to the export format discussion in #706. Happy to move or rename things to whatever layout you prefer.