### PR TITLE
Add offline ONNX sequence export example

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,4 +181,6 @@ Please see our [wiki](https://github.com/snakers4/silero-models/wiki) for releva
 
 - OpenVINO conversion [guidelines](https://github.com/snakers4/silero-vad/tree/master/examples/openvino)
 
+- Optional [offline ONNX sequence inference](examples/onnx_sequence) for long recordings
+
 - A tinygrad [model](https://github.com/snakers4/silero-vad/blob/master/src/silero_vad/tinygrad_model.py) with a pico example in the docsting + separate [weights](https://github.com/snakers4/silero-vad/blob/master/src/silero_vad/data/silero_vad_16k.safetensors) in safetensors format (for simplicity we provided just the 16k model)

--- a/examples/onnx_sequence/README.md
+++ b/examples/onnx_sequence/README.md
@@ -1,0 +1,65 @@
+# Offline ONNX Sequence Inference
+
+This optional example reduces ONNX Runtime call overhead when processing long offline recordings. It exports a graph that evaluates consecutive Silero VAD frames in one call while preserving the temporal LSTM state.
+
+The sequence axis represents consecutive frames from one recording. It is not a batch of independent recordings, and this example does not change the package loader, streaming API, or shipped models.
+
+## Setup
+
+Run the commands from the repository root. The exporter requires PyTorch and ONNX; the runner requires NumPy and ONNX Runtime:
+
+```bash
+python -m pip install torch onnx onnxruntime numpy
+```
+
+## Export
+
+Generate the model locally from the packaged TorchScript weights:
+
+```bash
+python examples/onnx_sequence/export.py \
+  --sample-rate 16000 \
+  --output silero_vad_16k_sequence.onnx
+```
+
+Use `--sample-rate 8000` to export the 8 kHz architecture. Generated ONNX files are not part of the package and should not be committed.
+
+The exporter reconstructs the public v5/v6 architecture, validates expected weight names and shapes, uses a dynamic sequence axis, and runs the ONNX model checker. The resulting model accepts:
+
+```text
+input: [sequence_length, frame_samples + context_samples]
+h:     [1, 1, 128]
+c:     [1, 1, 128]
+```
+
+It returns one speech probability per frame and the final hidden and cell states. The states and the previous frame's audio context must be carried into the next block.
+
+## Validate and benchmark
+
+`run.py` implements a bounded runner, compares it with the stock frame-at-a-time ONNX model, and exits with an error if probabilities or final recurrent state differ by more than `1e-6`. It also reports whether the results are array-exact:
+
+```bash
+python examples/onnx_sequence/run.py \
+  silero_vad_16k_sequence.onnx \
+  --sample-rate 16000 \
+  --seconds 60.01 \
+  --trials 5
+```
+
+You can validate an uncompressed mono PCM16 WAV with `--wav path/to/audio.wav`. The default 512-frame block covers 16.384 seconds at either supported sample rate and keeps model inputs bounded for recordings of any length.
+
+This example returns frame probabilities. Applications that need speech timestamps should feed those probabilities into their offline timestamp logic; the core `get_speech_timestamps` API remains unchanged.
+
+## Reference results
+
+The submitted `run.py` was measured on one pinned AMD Ryzen 5 5600X core with ONNX Runtime 1.27.0 using `CPUExecutionProvider` and one runtime thread. Timings include framing and probability inference; they exclude audio decoding, model export, session creation, and timestamp post-processing. The long input was this [69m20.679s recording](https://www.youtube.com/watch?v=Cdle09QLPLI), decoded once to 16 kHz mono PCM16 before timing.
+
+| Input | Stock frame ONNX | Sequence ONNX | Speedup | Output |
+| --- | ---: | ---: | ---: | --- |
+| 69m20.679s, 16 kHz | 11.8733 s | 4.8382 s | 2.45x | exact |
+| Repository 60s fixture, 16 kHz | 0.1651 s | 0.0705 s | 2.34x | exact |
+| Repository fixture resampled to 8 kHz | 0.1363 s | 0.0425 s | 3.21x | exact |
+
+Each result is the median of five alternating warmed trials. Timing varies by CPU and ONNX Runtime version; no timing threshold is used as a correctness check.
+
+The temporal-sequence approach was proposed in [discussion #408](https://github.com/snakers4/silero-vad/discussions/408) and later used by [faster-whisper](https://github.com/SYSTRAN/faster-whisper/pull/936). Bounded blocks follow the long-input handling added in [faster-whisper #1198](https://github.com/SYSTRAN/faster-whisper/pull/1198), and the v6 architecture follows [faster-whisper #1390](https://github.com/SYSTRAN/faster-whisper/pull/1390).

--- a/examples/onnx_sequence/export.py
+++ b/examples/onnx_sequence/export.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Export a state-preserving Silero VAD model for offline sequence inference."""
+
+import argparse
+import inspect
+from pathlib import Path
+from typing import Dict, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+REPOSITORY = Path(__file__).resolve().parents[2]
+RATE_CONFIG = {
+    8000: ("_model_8k", 256, 32),
+    16000: ("_model", 512, 64),
+}
+STATE_SIZE = 128
+
+
+class STFT(nn.Module):
+    def __init__(self, sample_rate: int):
+        super().__init__()
+        filter_length = int(sample_rate / 62.5)
+        self.filter_length = filter_length
+        self.hop_length = filter_length // 2
+        self.padding = nn.ReflectionPad1d(filter_length // 2)
+        self.register_buffer(
+            "forward_basis_buffer",
+            torch.zeros(filter_length + 2, 1, filter_length),
+        )
+
+    def forward(self, audio: torch.Tensor) -> torch.Tensor:
+        audio = self.padding(audio).unsqueeze(1)
+        transform = F.conv1d(
+            audio,
+            self.forward_basis_buffer,
+            stride=self.hop_length,
+        )
+        cutoff = self.filter_length // 2 + 1
+        real = transform[:, :cutoff, 1:]
+        imaginary = transform[:, cutoff:, 1:]
+        return torch.sqrt(real.pow(2) + imaginary.pow(2))
+
+
+class SequenceVad(nn.Module):
+    def __init__(self, sample_rate: int):
+        super().__init__()
+        input_channels = int(sample_rate / 125) + 1
+        self.stft = STFT(sample_rate)
+        self.encoder = nn.ModuleList(
+            [
+                nn.Conv1d(input_channels, 128, 3, padding=1),
+                nn.Conv1d(128, 64, 3, stride=2, padding=1),
+                nn.Conv1d(64, 64, 3, stride=2, padding=1),
+                nn.Conv1d(64, 128, 3, padding=1),
+            ]
+        )
+        self.recurrent = nn.LSTM(STATE_SIZE, STATE_SIZE)
+        self.output = nn.Conv1d(STATE_SIZE, 1, 1)
+
+    def forward(
+        self,
+        audio: torch.Tensor,
+        hidden: torch.Tensor,
+        cell: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        encoded = self.stft(audio)
+        for layer in self.encoder:
+            encoded = F.relu(layer(encoded))
+
+        # Rows are consecutive time steps, not independent batch elements.
+        decoded, (hidden, cell) = self.recurrent(
+            encoded.permute(0, 2, 1),
+            (hidden, cell),
+        )
+        probabilities = torch.sigmoid(self.output(F.relu(decoded).permute(1, 2, 0)))
+        return probabilities.reshape(-1), hidden, cell
+
+
+def weight_mapping(prefix: str) -> Dict[str, str]:
+    mapping = {
+        "stft.forward_basis_buffer": prefix + ".stft.forward_basis_buffer",
+        "recurrent.weight_ih_l0": prefix + ".decoder.rnn.weight_ih",
+        "recurrent.weight_hh_l0": prefix + ".decoder.rnn.weight_hh",
+        "recurrent.bias_ih_l0": prefix + ".decoder.rnn.bias_ih",
+        "recurrent.bias_hh_l0": prefix + ".decoder.rnn.bias_hh",
+        "output.weight": prefix + ".decoder.decoder.2.weight",
+        "output.bias": prefix + ".decoder.decoder.2.bias",
+    }
+    for index in range(4):
+        for parameter in ("weight", "bias"):
+            mapping["encoder.%d.%s" % (index, parameter)] = (
+                "%s.encoder.%d.reparam_conv.%s" % (prefix, index, parameter)
+            )
+    return mapping
+
+
+def load_weights(model: nn.Module, source: torch.jit.ScriptModule, prefix: str) -> None:
+    source_state = source.state_dict()
+    target_state = model.state_dict()
+    mapping = weight_mapping(prefix)
+    branch_names = {name for name in source_state if name.startswith(prefix + ".")}
+    if branch_names != set(mapping.values()):
+        raise RuntimeError(
+            "Source architecture differs from this example: missing=%s unexpected=%s"
+            % (
+                sorted(set(mapping.values()) - branch_names),
+                sorted(branch_names - set(mapping.values())),
+            )
+        )
+    remapped = {}
+    for target_name, source_name in mapping.items():
+        value = source_state[source_name]
+        if value.shape != target_state[target_name].shape:
+            raise RuntimeError(
+                "Unexpected shape for %s: expected %s, got %s"
+                % (
+                    source_name,
+                    tuple(target_state[target_name].shape),
+                    tuple(value.shape),
+                )
+            )
+        remapped[target_name] = value
+    model.load_state_dict(remapped, strict=True)
+
+
+def export_model(
+    source_path: Path,
+    output_path: Path,
+    sample_rate: int,
+    opset: int,
+) -> None:
+    import onnx
+
+    prefix, frame_samples, context_samples = RATE_CONFIG[sample_rate]
+    source = torch.jit.load(str(source_path), map_location="cpu")
+    source.eval()
+    model = SequenceVad(sample_rate)
+    load_weights(model, source, prefix)
+    model.eval()
+
+    frames = torch.zeros(10, frame_samples + context_samples)
+    state = torch.zeros(1, 1, STATE_SIZE)
+    options = {
+        "input_names": ["input", "h", "c"],
+        "output_names": ["speech_probs", "hn", "cn"],
+        "dynamic_axes": {
+            "input": {0: "sequence_length"},
+            "speech_probs": {0: "sequence_length"},
+        },
+        "opset_version": opset,
+    }
+    if "dynamo" in inspect.signature(torch.onnx.export).parameters:
+        options["dynamo"] = False
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with torch.inference_mode():
+        torch.onnx.export(
+            model,
+            (frames, state, state.clone()),
+            str(output_path),
+            **options,
+        )
+
+    exported = onnx.load(str(output_path))
+    onnx.checker.check_model(exported)
+
+
+def parse_args() -> argparse.Namespace:
+    data = REPOSITORY / "src" / "silero_vad" / "data"
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sample-rate",
+        type=int,
+        choices=sorted(RATE_CONFIG),
+        default=16000,
+    )
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=data / "silero_vad.jit",
+        help="source TorchScript model",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="output path (default: silero_vad_<rate>k_sequence.onnx)",
+    )
+    parser.add_argument("--opset", type=int, default=16)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    source = args.source.resolve(strict=True)
+    output = args.output or Path(
+        "silero_vad_%dk_sequence.onnx" % (args.sample_rate // 1000)
+    )
+    export_model(source, output.resolve(), args.sample_rate, args.opset)
+    print("Exported %s" % output.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/onnx_sequence/run.py
+++ b/examples/onnx_sequence/run.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Validate and benchmark an offline Silero VAD sequence ONNX model."""
+
+import argparse
+import statistics
+import time
+import wave
+from pathlib import Path
+from typing import Iterator, Tuple
+
+import numpy as np
+import onnxruntime as ort
+
+
+REPOSITORY = Path(__file__).resolve().parents[2]
+RATE_CONFIG = {
+    8000: (256, 32),
+    16000: (512, 64),
+}
+STATE_SHAPE = (2, 1, 128)
+
+
+def session(path: Path) -> ort.InferenceSession:
+    options = ort.SessionOptions()
+    options.inter_op_num_threads = 1
+    options.intra_op_num_threads = 1
+    return ort.InferenceSession(
+        str(path),
+        sess_options=options,
+        providers=["CPUExecutionProvider"],
+    )
+
+
+def frame_blocks(
+    audio: np.ndarray,
+    frame_samples: int,
+    context_samples: int,
+    max_frames: int,
+) -> Iterator[np.ndarray]:
+    frame_count = (audio.size + frame_samples - 1) // frame_samples
+    previous_context = np.zeros(context_samples, dtype=np.float32)
+    for first_frame in range(0, frame_count, max_frames):
+        block_frames = min(max_frames, frame_count - first_frame)
+        first_sample = first_frame * frame_samples
+        samples = audio[
+            first_sample : min(audio.size, (first_frame + block_frames) * frame_samples)
+        ]
+        frames = np.zeros((block_frames, frame_samples), dtype=np.float32)
+        frames.reshape(-1)[: samples.size] = samples
+
+        contexts = np.empty((block_frames, context_samples), dtype=np.float32)
+        contexts[0] = previous_context
+        if block_frames > 1:
+            contexts[1:] = frames[:-1, -context_samples:]
+        previous_context = frames[-1, -context_samples:].copy()
+        yield np.concatenate((contexts, frames), axis=1)
+
+
+def run_stock(
+    model: ort.InferenceSession,
+    audio: np.ndarray,
+    sample_rate: int,
+    initial_state: np.ndarray,
+    max_frames: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    frame_samples, context_samples = RATE_CONFIG[sample_rate]
+    state = initial_state.copy()
+    probabilities = []
+    rate = np.asarray(sample_rate, dtype=np.int64)
+    for block in frame_blocks(audio, frame_samples, context_samples, max_frames):
+        for model_input in block:
+            probability, state = model.run(
+                ["output", "stateN"],
+                {
+                    "input": model_input.reshape(1, -1),
+                    "state": state,
+                    "sr": rate,
+                },
+            )
+            probabilities.append(float(probability[0, 0]))
+    return np.asarray(probabilities, dtype=np.float32), state
+
+
+def run_sequence(
+    model: ort.InferenceSession,
+    audio: np.ndarray,
+    sample_rate: int,
+    initial_state: np.ndarray,
+    max_frames: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    frame_samples, context_samples = RATE_CONFIG[sample_rate]
+    hidden = initial_state[0:1].copy()
+    cell = initial_state[1:2].copy()
+    probabilities = []
+    for block in frame_blocks(audio, frame_samples, context_samples, max_frames):
+        values, hidden, cell = model.run(
+            ["speech_probs", "hn", "cn"],
+            {"input": block, "h": hidden, "c": cell},
+        )
+        probabilities.append(values)
+    return np.concatenate(probabilities), np.concatenate((hidden, cell), axis=0)
+
+
+def read_wav(path: Path, sample_rate: int) -> np.ndarray:
+    with wave.open(str(path), "rb") as source:
+        if (
+            source.getframerate() != sample_rate
+            or source.getnchannels() != 1
+            or source.getsampwidth() != 2
+            or source.getcomptype() != "NONE"
+        ):
+            raise ValueError(
+                "%s must be uncompressed %d Hz mono PCM16" % (path, sample_rate)
+            )
+        audio = np.frombuffer(
+            source.readframes(source.getnframes()),
+            dtype="<i2",
+        )
+    return audio.astype(np.float32) / 32768.0
+
+
+def parse_args() -> argparse.Namespace:
+    data = REPOSITORY / "src" / "silero_vad" / "data"
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sequence_model", type=Path)
+    parser.add_argument(
+        "--stock-model",
+        type=Path,
+        default=data / "silero_vad.onnx",
+    )
+    parser.add_argument(
+        "--sample-rate",
+        type=int,
+        choices=sorted(RATE_CONFIG),
+        default=16000,
+    )
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--wav", type=Path, help="uncompressed mono PCM16 WAV")
+    source.add_argument(
+        "--seconds",
+        type=float,
+        default=60.01,
+        help="duration of deterministic synthetic input (default: 60.01)",
+    )
+    parser.add_argument("--max-frames", type=int, default=512)
+    parser.add_argument("--trials", type=int, default=5)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.max_frames < 1 or args.trials < 1:
+        raise SystemExit("--max-frames and --trials must be positive")
+    if args.wav:
+        audio = read_wav(args.wav.resolve(strict=True), args.sample_rate)
+    else:
+        if args.seconds <= 0:
+            raise SystemExit("--seconds must be positive")
+        random = np.random.default_rng(17 + args.sample_rate)
+        audio = (
+            random.standard_normal(round(args.seconds * args.sample_rate)) * 0.03
+        ).astype(np.float32)
+    if audio.size == 0:
+        raise SystemExit("input audio is empty")
+
+    stock = session(args.stock_model.resolve(strict=True))
+    sequence = session(args.sequence_model.resolve(strict=True))
+    random = np.random.default_rng(29 + args.sample_rate)
+    initial_state = (random.standard_normal(STATE_SHAPE) * 0.01).astype(np.float32)
+
+    frame_samples = RATE_CONFIG[args.sample_rate][0]
+    warmup = audio[: min(audio.size, 16 * frame_samples)]
+    run_stock(stock, warmup, args.sample_rate, initial_state, args.max_frames)
+    run_sequence(sequence, warmup, args.sample_rate, initial_state, args.max_frames)
+
+    runners = {
+        "stock": (run_stock, stock),
+        "sequence": (run_sequence, sequence),
+    }
+    times = {name: [] for name in runners}
+    outputs = {}
+    for trial in range(args.trials):
+        order = ("stock", "sequence") if trial % 2 == 0 else ("sequence", "stock")
+        for name in order:
+            function, model = runners[name]
+            started = time.perf_counter()
+            outputs[name] = function(
+                model,
+                audio,
+                args.sample_rate,
+                initial_state,
+                args.max_frames,
+            )
+            times[name].append(time.perf_counter() - started)
+
+    expected_probabilities, expected_state = outputs["stock"]
+    actual_probabilities, actual_state = outputs["sequence"]
+    comparisons = {}
+    for label, actual_values, expected_values in (
+        ("probability", actual_probabilities, expected_probabilities),
+        ("state", actual_state, expected_state),
+    ):
+        if actual_values.shape != expected_values.shape:
+            raise SystemExit(
+                "%s shape mismatch: %s != %s"
+                % (label, actual_values.shape, expected_values.shape)
+            )
+        difference = float(np.max(np.abs(actual_values - expected_values)))
+        comparisons[label] = (
+            difference,
+            np.array_equal(actual_values, expected_values),
+        )
+        if not np.allclose(actual_values, expected_values, rtol=0, atol=1e-6):
+            raise SystemExit(
+                "%s mismatch: max abs difference %.9g" % (label, difference)
+            )
+
+    stock_median = statistics.median(times["stock"])
+    sequence_median = statistics.median(times["sequence"])
+    print(
+        "Validated %d frames at %d Hz: max abs diff %.3g, bit-exact=%s"
+        % (
+            actual_probabilities.size,
+            args.sample_rate,
+            max(item[0] for item in comparisons.values()),
+            all(item[1] for item in comparisons.values()),
+        )
+    )
+    print("Stock ONNX median:    %.4f s" % stock_median)
+    print("Sequence ONNX median: %.4f s" % sequence_median)
+    print("Speedup:              %.2fx" % (stock_median / sequence_median))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
> **AI-generated PR disclosure:** This is an AI-generated pull request, prepared after three days of implementation, testing, and benchmarking in our [Cohere Arabic batch-inference project](https://github.com/AliOsm/cohere-transcribe-arabic-batch-inference). The reduced example was then independently reviewed and checked against the stock Silero ONNX model before publication.

## Summary

This adds a self-contained example for faster ONNX inference on long offline recordings:

```text
examples/onnx_sequence/
├── README.md
├── export.py
└── run.py
```

Following the maintainer feedback, this revision makes no changes to `/src`, the package API, Torch Hub, dependencies, streaming behavior, or shipped model files. Users generate the architecture-specific ONNX model locally when the optimization fits their workload.

The stock ONNX path enters ONNX Runtime once per 32 ms frame. The example evaluates the stateless encoder over consecutive frames in one call, then runs those encoded frames through one temporal ONNX `LSTM`. The leading dimension is time from one recording, not a batch of independent recordings.

## Usage

Export either supported sample rate from the packaged TorchScript weights:

```bash
python examples/onnx_sequence/export.py \
  --sample-rate 16000 \
  --output silero_vad_16k_sequence.onnx
```

Validate the generated graph against the stock frame graph and benchmark bounded sequence inference:

```bash
python examples/onnx_sequence/run.py \
  silero_vad_16k_sequence.onnx \
  --sample-rate 16000 \
  --seconds 60.01 \
  --trials 5
```

Generated ONNX files remain local and are not committed.

## Correctness

The exporter:

- Supports the packaged 8 kHz and 16 kHz architectures.
- Validates the expected source weight names and every tensor shape.
- Uses a dynamic temporal axis while keeping the recurrent batch fixed at one.
- Forces the established TorchScript ONNX exporter where supported.
- Runs the ONNX model checker before reporting success.

The runner bounds calls to 512 frames, carries hidden state, cell state, and prior raw-audio context across blocks, and zero-pads only a partial final frame. It compares every probability and the final recurrent state with the stock v6.2.1 ONNX graph on `CPUExecutionProvider`. It fails above a `1e-6` absolute difference and separately reports whether results are array-exact.

Validation covered both sample rates, random nonzero initial states, context and frame boundaries, partial frames, 512-frame block boundaries, block sizes from 1 to 10,000, the repository's real fixtures, and both v5.1.2 and v6.2.1 source models. All tested CPU ONNX Runtime comparisons were array-exact.

## Performance

The submitted `run.py` was measured on one pinned AMD Ryzen 5 5600X core with ONNX Runtime 1.27.0, `CPUExecutionProvider`, and one runtime thread. Timings include framing and probability inference. They exclude audio decoding, export, session creation, and timestamp post-processing.

| Input | Stock frame ONNX | Sequence ONNX | Speedup | Output |
| --- | ---: | ---: | ---: | --- |
| [69m20.679s recording](https://www.youtube.com/watch?v=Cdle09QLPLI), 16 kHz | 11.8733 s | 4.8382 s | 2.45x | exact |
| Repository 60s fixture, 16 kHz | 0.1651 s | 0.0705 s | 2.34x | exact |
| Repository fixture resampled to 8 kHz | 0.1363 s | 0.0425 s | 3.21x | exact |

Each result is the median of five alternating warmed trials. No timing threshold is used as a correctness check.

## Scope

This is an optional example for long offline recordings. It returns frame probabilities and deliberately does not integrate with `get_speech_timestamps` or the streaming API. Applications can feed the probabilities into their own offline timestamp logic. The default Silero package remains unchanged.

The approach was proposed by @IntendedConsequence in [discussion #408](https://github.com/snakers4/silero-vad/discussions/408) and later used by @MahmoudAshraf97 in [faster-whisper #936](https://github.com/SYSTRAN/faster-whisper/pull/936). Bounded long-input handling follows [faster-whisper #1198](https://github.com/SYSTRAN/faster-whisper/pull/1198), and the v6 architecture follows [faster-whisper #1390](https://github.com/SYSTRAN/faster-whisper/pull/1390).

## Validation performed

```text
8 kHz export + ONNX checker + stock parity: passed
16 kHz export + ONNX checker + stock parity: passed
Repository real-audio fixtures: passed
Block-boundary and partial-frame property checks: passed
Core repository tests: 2 passed
Ruff Python 3.8 lint and formatting: passed
Python bytecode compilation: passed
git diff --check: passed
Wheel build: passed
```
